### PR TITLE
Add header row to printUserDetails()

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,4 +1,4 @@
-import {vi, expect, it, describe, Mock} from "vitest";
+import {vi, expect, it, describe} from "vitest";
 import {User} from "./types";
 import {printUserDetails} from "./index";
 import {userDetails} from "./functions";
@@ -17,29 +17,11 @@ describe('printUserDetails()', () => {
             studentId: "DS12345"
         }
 
+        console.log = vi.fn();
+
         printUserDetails(testUser);
 
         expect(userDetails).toHaveBeenCalledWith(testUser);
-
-    });
-
-    it ('should print the correct user details to the console', () => {
-
-        const testUser: User = {
-            id: 1,
-            userName: "DS123",
-            firstName: "Dummy",
-            lastName: "User",
-            studentId: "DS12345"
-        }
-
-        console.log = vi.fn();
-
-        vi.mocked(userDetails).mockReturnValue('1|DS123|Dummy|User|DS12345');
-
-        printUserDetails(testUser);
-
-        expect(console.log).toHaveBeenCalledWith('1|DS123|Dummy|User|DS12345');
 
     });
 
@@ -59,8 +41,7 @@ describe('printUserDetails()', () => {
 
         printUserDetails(testUser);
 
-        expect(console.log).toHaveBeenCalledWith('EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID');
-        expect(console.log).toHaveBeenCalledWith('1|DS123|Dummy|User|DS12345');
+        expect(console.log).toHaveBeenCalledWith('EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID \n1|DS123|Dummy|User|DS12345');
 
     });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -42,4 +42,25 @@ describe('printUserDetails()', () => {
         expect(console.log).toHaveBeenCalledWith('1|DS123|Dummy|User|DS12345');
 
     });
+
+    it ('should print the header row before outputting the user details', () => {
+
+        const testUser: User = {
+            id: 1,
+            userName: "DS123",
+            firstName: "Dummy",
+            lastName: "User",
+            studentId: "DS12345"
+        }
+
+        console.log = vi.fn();
+
+        vi.mocked(userDetails).mockReturnValue('1|DS123|Dummy|User|DS12345');
+
+        printUserDetails(testUser);
+
+        expect(console.log).toHaveBeenCalledWith('EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID');
+        expect(console.log).toHaveBeenCalledWith('1|DS123|Dummy|User|DS12345');
+
+    });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -41,7 +41,8 @@ describe('printUserDetails()', () => {
 
         printUserDetails(testUser);
 
-        expect(console.log).toHaveBeenCalledWith('EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID \n1|DS123|Dummy|User|DS12345');
+        expect(console.log).toHaveBeenCalledWith('EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID' + '\n' +
+        '1|DS123|Dummy|User|DS12345');
 
     });
 });

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,8 @@ const student: User = {
 }
 
 export const printUserDetails = (user: User) => {
-    const output = `EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID \n${userDetails(user)}`
+    const output = "EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID"  + "\n" +
+    `${userDetails(user)}`
     console.log(output)
 };
 

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ const student: User = {
 
 export const printUserDetails = (user: User) => {
     const output = "EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID"  + "\n" +
-    `${userDetails(user)}`
+    userDetails(user)
     console.log(output)
 };
 

--- a/index.ts
+++ b/index.ts
@@ -10,8 +10,8 @@ const student: User = {
 }
 
 export const printUserDetails = (user: User) => {
-    console.log('EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID')
-    console.log(userDetails(user))
+    const output = `EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID \n${userDetails(user)}`
+    console.log(output)
 };
 
 printUserDetails(student)

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ const student: User = {
 }
 
 export const printUserDetails = (user: User) => {
+    console.log('EXTERNAL_PERSON_KEY|USER_ID|FIRSTNAME|LASTNAME|STUDENT_ID')
     console.log(userDetails(user))
 };
 


### PR DESCRIPTION
Implement a header row to printUserDetails() that will be output prior to displaying the user details.

Also, implement a test to verify that the printUserDetails() is behaving as expected i.e. printing header before outputting the user details.